### PR TITLE
Runner structure overhaul

### DIFF
--- a/torch_nerf/runners/run_render.py
+++ b/torch_nerf/runners/run_render.py
@@ -1,20 +1,13 @@
 """A script for scene rendering."""
 
-import os
 import sys
+
+import hydra
+from omegaconf import DictConfig
 
 sys.path.append(".")
 sys.path.append("..")
 
-import hydra
-from hydra.core.hydra_config import HydraConfig
-import numpy as np
-from omegaconf import DictConfig
-import torch
-from torch.utils.tensorboard import SummaryWriter
-import torchvision.utils as tvu
-from tqdm import tqdm
-import torch_nerf.src.renderer.cameras as cameras
 import torch_nerf.runners.runner_utils as runner_utils
 
 
@@ -25,45 +18,8 @@ import torch_nerf.runners.runner_utils as runner_utils
 )
 def main(cfg: DictConfig) -> None:
     """The entry point of rendering code."""
-    log_dir = os.path.join("render_out", cfg.data.dataset_type, cfg.data.scene_name)
-
-    # configure device
-    runner_utils._init_cuda(cfg)
-
-    # initialize data, renderer, and scene
-    dataset, _ = runner_utils._init_dataset_and_loader(cfg)
-    renderer = runner_utils._init_renderer(cfg)
-    scenes = runner_utils._init_scene_repr(cfg)
-
-    if cfg.train_params.ckpt.path is None:
-        raise ValueError("Checkpoint file must be provided for rendering.")
-    if not os.path.exists(cfg.train_params.ckpt.path):
-        raise ValueError("Checkpoint file does not exist.")
-
-    # load scene representation
-    _ = runner_utils._load_ckpt(
-        cfg.train_params.ckpt.path,
-        scenes,
-        optimizer=None,
-        scheduler=None,
-    )
-
-    # render
-    runner_utils._visualize_scene(
-        cfg,
-        scenes,
-        renderer,
-        intrinsics={
-            "f_x": dataset.focal_length,
-            "f_y": dataset.focal_length,
-            "img_width": dataset.img_width,
-            "img_height": dataset.img_height,
-        },
-        extrinsics=dataset.render_poses,
-        img_res=(dataset.img_height, dataset.img_width),
-        save_dir=log_dir,
-    )
-
+    render_session = runner_utils.init_session(cfg, mode="render")
+    render_session()
     print("Rendering done.")
 
 

--- a/torch_nerf/runners/run_render.py
+++ b/torch_nerf/runners/run_render.py
@@ -28,12 +28,12 @@ def main(cfg: DictConfig) -> None:
     log_dir = os.path.join("render_out", cfg.data.dataset_type, cfg.data.scene_name)
 
     # configure device
-    runner_utils.init_cuda(cfg)
+    runner_utils._init_cuda(cfg)
 
     # initialize data, renderer, and scene
-    dataset, _ = runner_utils.init_dataset_and_loader(cfg)
-    renderer = runner_utils.init_renderer(cfg)
-    scenes = runner_utils.init_scene_repr(cfg)
+    dataset, _ = runner_utils._init_dataset_and_loader(cfg)
+    renderer = runner_utils._init_renderer(cfg)
+    scenes = runner_utils._init_scene_repr(cfg)
 
     if cfg.train_params.ckpt.path is None:
         raise ValueError("Checkpoint file must be provided for rendering.")
@@ -41,7 +41,7 @@ def main(cfg: DictConfig) -> None:
         raise ValueError("Checkpoint file does not exist.")
 
     # load scene representation
-    _ = runner_utils.load_ckpt(
+    _ = runner_utils._load_ckpt(
         cfg.train_params.ckpt.path,
         scenes,
         optimizer=None,
@@ -49,7 +49,7 @@ def main(cfg: DictConfig) -> None:
     )
 
     # render
-    runner_utils.visualize_scene(
+    runner_utils._visualize_scene(
         cfg,
         scenes,
         renderer,

--- a/torch_nerf/runners/run_train.py
+++ b/torch_nerf/runners/run_train.py
@@ -78,6 +78,7 @@ def train_one_epoch(
             cfg.renderer.t_far,
         )
 
+        # TODO: The codes below are dependent to the original NeRF setup
         # forward prop. coarse network
         coarse_pred, coarse_indices, coarse_weights = renderer.render_scene(
             scenes["coarse"],
@@ -135,17 +136,17 @@ def main(cfg: DictConfig) -> None:
     log_dir = HydraConfig.get().runtime.output_dir
 
     # configure device
-    runner_utils.init_cuda(cfg)
+    runner_utils._init_cuda(cfg)
 
     # initialize data, renderer, and scene
-    dataset, loader = runner_utils.init_dataset_and_loader(cfg)
-    renderer = runner_utils.init_renderer(cfg)
-    scenes = runner_utils.init_scene_repr(cfg)
-    optimizer, scheduler = runner_utils.init_optimizer_and_scheduler(cfg, scenes)
-    loss_func = runner_utils.init_objective_func(cfg)
+    dataset, loader = runner_utils._init_dataset_and_loader(cfg)
+    renderer = runner_utils._init_renderer(cfg)
+    scenes = runner_utils._init_scene_repr(cfg)
+    optimizer, scheduler = runner_utils._init_optimizer_and_scheduler(cfg, scenes)
+    loss_func = runner_utils._init_objective_func(cfg)
 
     # load if checkpoint exists
-    start_epoch = runner_utils.load_ckpt(
+    start_epoch = runner_utils._load_ckpt(
         cfg.train_params.ckpt.path,
         scenes,
         optimizer,
@@ -171,7 +172,7 @@ def main(cfg: DictConfig) -> None:
         if (epoch + 1) % cfg.train_params.log.epoch_btw_ckpt == 0:
             ckpt_dir = os.path.join(log_dir, "ckpt")
 
-            runner_utils.save_ckpt(
+            runner_utils._save_ckpt(
                 ckpt_dir,
                 epoch,
                 scenes,
@@ -186,7 +187,7 @@ def main(cfg: DictConfig) -> None:
                 f"vis/epoch_{epoch}",
             )
 
-            runner_utils.visualize_scene(
+            runner_utils._visualize_scene(
                 cfg,
                 scenes,
                 renderer,

--- a/torch_nerf/runners/run_train.py
+++ b/torch_nerf/runners/run_train.py
@@ -1,128 +1,14 @@
 """A script for training."""
 
-import os
 import sys
+
+import hydra
+from omegaconf import DictConfig
 
 sys.path.append(".")
 sys.path.append("..")
 
-import hydra
-from hydra.core.hydra_config import HydraConfig
-import numpy as np
-from omegaconf import DictConfig
-import torch
-from torch.utils.tensorboard import SummaryWriter
-import torchvision.utils as tvu
-from tqdm import tqdm
-import torch_nerf.src.renderer.cameras as cameras
 import torch_nerf.runners.runner_utils as runner_utils
-
-
-def train_one_epoch(
-    cfg,
-    scenes,
-    renderer,
-    dataset,
-    loader,
-    loss_func,
-    optimizer,
-    scheduler=None,
-) -> float:
-    """
-    Trains the scene for one epoch.
-
-    Args:
-        cfg (DictConfig): A config object holding parameters required
-            to setup scene representation.
-        scene (QueryStruct): Neural scene representation to be optimized.
-        renderer (VolumeRenderer): Volume renderer used to render the scene.
-        dataset (torch.utils.data.Dataset): Dataset for training data.
-        loader (torch.utils.data.DataLoader): Loader for training data.
-        loss_func (torch.nn.Module): Objective function to be optimized.
-        optimizer (torch.optim.Optimizer): Optimizer.
-        scheduler (torch.optim.lr_scheduler.ExponentialLR): Learning rate scheduler.
-            Set to None by default.
-
-    Returns:
-        total_loss (float): The average of losses computed over an epoch.
-    """
-    if not "coarse" in scenes.keys():
-        raise ValueError(
-            "At least a coarse representation the scene is required for training. "
-            f"Got a dictionary whose keys are {scenes.keys()}."
-        )
-
-    total_loss = 0.0
-    total_coarse_loss = 0.0
-    total_fine_loss = 0.0
-
-    for batch in loader:
-        pixel_gt, extrinsic = batch
-        pixel_gt = pixel_gt.squeeze()
-        pixel_gt = torch.reshape(pixel_gt, (-1, 3))  # (H, W, 3) -> (H * W, 3)
-        extrinsic = extrinsic.squeeze()
-
-        # initialize gradients
-        optimizer.zero_grad()
-
-        # set the camera
-        renderer.camera = cameras.PerspectiveCamera(
-            {
-                "f_x": dataset.focal_length,
-                "f_y": dataset.focal_length,
-                "img_width": dataset.img_width,
-                "img_height": dataset.img_height,
-            },
-            extrinsic,
-            cfg.renderer.t_near,
-            cfg.renderer.t_far,
-        )
-
-        # TODO: The codes below are dependent to the original NeRF setup
-        # forward prop. coarse network
-        coarse_pred, coarse_indices, coarse_weights = renderer.render_scene(
-            scenes["coarse"],
-            num_pixels=cfg.renderer.num_pixels,
-            num_samples=cfg.renderer.num_samples_coarse,
-            project_to_ndc=cfg.renderer.project_to_ndc,
-            device=torch.cuda.current_device(),
-        )
-        loss = loss_func(pixel_gt[coarse_indices, ...].cuda(), coarse_pred)
-        total_coarse_loss += loss.item()
-
-        # forward prop. fine network
-        if "fine" in scenes.keys():
-            fine_pred, fine_indices, _ = renderer.render_scene(
-                scenes["fine"],
-                num_pixels=cfg.renderer.num_pixels,
-                num_samples=(cfg.renderer.num_samples_coarse, cfg.renderer.num_samples_fine),
-                project_to_ndc=cfg.renderer.project_to_ndc,
-                pixel_indices=coarse_indices,  # sample the ray from the same pixels
-                weights=coarse_weights,
-                device=torch.cuda.current_device(),
-            )
-            fine_loss = loss_func(pixel_gt[fine_indices, ...].cuda(), fine_pred)
-            total_fine_loss += fine_loss.item()
-            loss += fine_loss
-
-        total_loss += loss.item()
-
-        # step
-        loss.backward()
-        optimizer.step()
-        if not scheduler is None:
-            scheduler.step()
-
-    # compute average loss
-    total_loss /= len(loader)
-    total_coarse_loss /= len(loader)
-    total_fine_loss /= len(loader)
-
-    return {
-        "total_loss": total_loss,
-        "total_coarse_loss": total_coarse_loss,
-        "total_fine_loss": total_fine_loss,
-    }
 
 
 @hydra.main(
@@ -132,78 +18,8 @@ def train_one_epoch(
 )
 def main(cfg: DictConfig) -> None:
     """The entry point of training code."""
-    # identify log directory
-    log_dir = HydraConfig.get().runtime.output_dir
-
-    # configure device
-    runner_utils._init_cuda(cfg)
-
-    # initialize data, renderer, and scene
-    dataset, loader = runner_utils._init_dataset_and_loader(cfg)
-    renderer = runner_utils._init_renderer(cfg)
-    scenes = runner_utils._init_scene_repr(cfg)
-    optimizer, scheduler = runner_utils._init_optimizer_and_scheduler(cfg, scenes)
-    loss_func = runner_utils._init_objective_func(cfg)
-
-    # load if checkpoint exists
-    start_epoch = runner_utils._load_ckpt(
-        cfg.train_params.ckpt.path,
-        scenes,
-        optimizer,
-        scheduler,
-    )
-
-    # initialize writer
-    tb_log_dir = os.path.join(log_dir, "tensorboard")
-    if not os.path.exists(tb_log_dir):
-        os.mkdir(tb_log_dir)
-    writer = SummaryWriter(log_dir=tb_log_dir)
-
-    # train the model
-    for epoch in tqdm(range(start_epoch, cfg.train_params.optim.num_iter // len(dataset))):
-        # train
-        losses = train_one_epoch(
-            cfg, scenes, renderer, dataset, loader, loss_func, optimizer, scheduler
-        )
-        for loss_name, value in losses.items():
-            writer.add_scalar(f"Loss/{loss_name}", value, epoch)
-
-        # save checkpoint
-        if (epoch + 1) % cfg.train_params.log.epoch_btw_ckpt == 0:
-            ckpt_dir = os.path.join(log_dir, "ckpt")
-
-            runner_utils._save_ckpt(
-                ckpt_dir,
-                epoch,
-                scenes,
-                optimizer,
-                scheduler,
-            )
-
-        # visualize
-        if (epoch + 1) % cfg.train_params.log.epoch_btw_vis == 0:
-            save_dir = os.path.join(
-                log_dir,
-                f"vis/epoch_{epoch}",
-            )
-
-            runner_utils._visualize_scene(
-                cfg,
-                scenes,
-                renderer,
-                intrinsics={
-                    "f_x": dataset.focal_length,
-                    "f_y": dataset.focal_length,
-                    "img_width": dataset.img_width,
-                    "img_height": dataset.img_height,
-                },
-                extrinsics=dataset.render_poses,
-                img_res=(dataset.img_height, dataset.img_width),
-                save_dir=save_dir,
-                num_imgs=1,
-            )
-
-    writer.flush()
+    train_session = runner_utils.init_session(cfg, mode="train")
+    train_session()
 
 
 if __name__ == "__main__":

--- a/torch_nerf/runners/runner_utils.py
+++ b/torch_nerf/runners/runner_utils.py
@@ -61,6 +61,14 @@ def init_session(cfg: DictConfig) -> Callable:
     # initialize objective function
     loss_func = _init_loss_func(cfg)
 
+    # load if checkpoint exists
+    start_epoch = _load_ckpt(
+        cfg.train_params.ckpt.path,
+        default_scene,
+        fine_scene,
+        optimizer,
+        scheduler,
+    )
 
     # build train, validation, and visualization routine
     # with their parameters binded

--- a/torch_nerf/runners/runner_utils.py
+++ b/torch_nerf/runners/runner_utils.py
@@ -19,9 +19,14 @@ from torch_nerf.src.utils.data.blender_dataset import NeRFBlenderDataset
 from torch_nerf.src.utils.data.llff_dataset import LLFFDataset
 
 
-def init_cuda(cfg: DictConfig) -> None:
+
+def _init_cuda(cfg: DictConfig) -> None:
     """
     Checks availability of CUDA devices in the system and set the default device.
+
+    Args:
+        cfg (DictConfig): A config object holding parameters required
+            to configure CUDA devices.
     """
     if torch.cuda.is_available():
         device_id = cfg.cuda.device_id
@@ -40,7 +45,7 @@ def init_cuda(cfg: DictConfig) -> None:
         print("CUDA is not supported on this system. Using CPU by default.")
 
 
-def init_dataset_and_loader(
+def _init_dataset_and_loader(
     cfg: DictConfig,
 ) -> Tuple[data.Dataset, data.DataLoader]:
     """
@@ -110,7 +115,7 @@ def init_dataset_and_loader(
     return dataset, loader
 
 
-def init_renderer(cfg: DictConfig):
+def _init_renderer(cfg: DictConfig):
     """
     Initializes the renderer for rendering scene representations.
 
@@ -137,7 +142,8 @@ def init_renderer(cfg: DictConfig):
     return renderer
 
 
-def init_scene_repr(cfg: DictConfig) -> scene.PrimitiveBase:
+
+def _init_scene_repr(cfg: DictConfig) -> Tuple[scene.PrimitiveBase, Optional[scene.PrimitiveBase]]:
     """
     Initializes the scene representation to be trained / tested.
 
@@ -206,7 +212,7 @@ def init_scene_repr(cfg: DictConfig) -> scene.PrimitiveBase:
         raise ValueError("Unsupported scene representation.")
 
 
-def init_optimizer_and_scheduler(cfg: DictConfig, scenes):
+def _init_optimizer_and_scheduler(cfg: DictConfig, scenes):
     """
     Initializes the optimizer and learning rate scheduler used for training.
 
@@ -262,7 +268,7 @@ def init_optimizer_and_scheduler(cfg: DictConfig, scenes):
     return optimizer, scheduler
 
 
-def init_objective_func(cfg: DictConfig) -> torch.nn.Module:
+def _init_objective_func(cfg: DictConfig) -> torch.nn.Module:
     """
     Initializes objective functions used to train neural radiance fields.
 
@@ -280,7 +286,7 @@ def init_objective_func(cfg: DictConfig) -> torch.nn.Module:
         raise ValueError("Unsupported loss configuration.")
 
 
-def save_ckpt(
+def _save_ckpt(
     ckpt_dir: str,
     epoch: int,
     scenes,
@@ -315,7 +321,7 @@ def save_ckpt(
     )
 
 
-def load_ckpt(
+def _load_ckpt(
     ckpt_file,
     scenes,
     optimizer,
@@ -359,7 +365,7 @@ def load_ckpt(
     return epoch
 
 
-def visualize_scene(
+def _visualize_scene(
     cfg,
     scenes,
     renderer,

--- a/torch_nerf/runners/runner_utils.py
+++ b/torch_nerf/runners/runner_utils.py
@@ -382,17 +382,19 @@ def _save_ckpt(
 
 def _load_ckpt(
     ckpt_file,
-    scenes,
-    optimizer,
-    scheduler=None,
+    default_scene: scene.scene,
+    fine_scene: scene.scene,
+    optimizer: torch.optim.Optimizer,
+    scheduler: object = None,
 ) -> int:
     """
     Loads the checkpoint.
 
     Args:
         ckpt_file (str): A path to the checkpoint file.
-        scenes ():
-        optimizer ():
+        default_scene (scene.scene):
+        fine_scene (scene.scene):
+        optimizer (torch.optim.Optimizer):
         scheduler ():
 
     Returns:
@@ -409,10 +411,12 @@ def _load_ckpt(
     # load epoch
     epoch = ckpt["epoch"]
 
-    # load scene
-    for scene_type, scene in scenes.items():
-        scene.radiance_field.load_state_dict(ckpt[f"scene_{scene_type}"])
-        scene.radiance_field.to(torch.cuda.current_device())
+    # load scene(s)
+    default_scene.radiance_field.load_state_dict(ckpt["scene_default"])
+    default_scene.radiance_field.to(torch.cuda.current_device())
+    if not fine_scene is None:
+        fine_scene.radiance_field.load_state_dict(ckpt["scene_fine"])
+        fine_scene.radiance_field.to(torch.cuda.current_device())
 
     # load optimizer and scheduler states
     if not optimizer is None:

--- a/torch_nerf/runners/runner_utils.py
+++ b/torch_nerf/runners/runner_utils.py
@@ -320,7 +320,7 @@ def _init_optimizer_and_scheduler(
     return optimizer, scheduler
 
 
-def _init_objective_func(cfg: DictConfig) -> torch.nn.Module:
+def _init_loss_func(cfg: DictConfig) -> torch.nn.Module:
     """
     Initializes objective functions used to train neural radiance fields.
 

--- a/torch_nerf/runners/runner_utils.py
+++ b/torch_nerf/runners/runner_utils.py
@@ -1,11 +1,13 @@
 """A set of utility functions commonly used in training/testing scripts."""
 
 import os
-from typing import Dict, Tuple, Union
+from typing import Callable, Dict, Optional, Tuple, Union
 
+from hydra.core.hydra_config import HydraConfig
 from omegaconf import DictConfig
 import torch
 import torch.utils.data as data
+from torch.utils.tensorboard import SummaryWriter
 import torchvision.utils as tvu
 from tqdm import tqdm
 import torch_nerf.src.network as network

--- a/torch_nerf/runners/runner_utils.py
+++ b/torch_nerf/runners/runner_utils.py
@@ -1,5 +1,6 @@
 """A set of utility functions commonly used in training/testing scripts."""
 
+import functools
 import os
 from typing import Callable, Dict, Optional, Tuple, Union
 
@@ -59,6 +60,35 @@ def init_session(cfg: DictConfig) -> Callable:
 
     # initialize objective function
     loss_func = _init_loss_func(cfg)
+
+
+    # build train, validation, and visualization routine
+    # with their parameters binded
+    train_one_epoch = _build_train_routine(cfg)
+    validate_one_epoch = _build_validation_routine(cfg)
+    vis_one_epoch = _build_visualization_routine(cfg)
+
+def _build_train_routine(cfg) -> Callable:
+    """ """
+
+    def a(p):
+        return p + 1
+
+    return functools.partial(a, 1)
+
+
+def _build_validation_routine(cfg) -> Callable:
+    """ """
+    return None
+
+
+def _build_visualization_routine(cfg) -> Callable:
+    """ """
+
+    def a(p):
+        return p + 1
+
+    return functools.partial(a, 1)
 
 
 def _init_cuda(cfg: DictConfig) -> None:

--- a/torch_nerf/runners/runner_utils.py
+++ b/torch_nerf/runners/runner_utils.py
@@ -341,8 +341,9 @@ def _init_loss_func(cfg: DictConfig) -> torch.nn.Module:
 def _save_ckpt(
     ckpt_dir: str,
     epoch: int,
-    scenes,
-    optimizer,
+    default_scene: scene.scene,
+    fine_scene: scene.scene,
+    optimizer: torch.optim.Optimizer,
     scheduler,
 ) -> None:
     """
@@ -350,7 +351,8 @@ def _save_ckpt(
 
     Args:
         epoch (int):
-        scenes (Dict):
+        default_scene (scene.scene):
+        fine_scene (scene.scene):
         optimizer ():
         scheduler ():
     """
@@ -361,11 +363,16 @@ def _save_ckpt(
     ckpt = {
         "epoch": epoch,
         "optimizer_state_dict": optimizer.state_dict(),
-        "scheduler_state_dict": scheduler.state_dict(),
     }
 
-    for scene_type, scene in scenes.items():
-        ckpt[f"scene_{scene_type}"] = scene.radiance_field.state_dict()
+    # save scheduler state
+    if not scheduler is None:
+        ckpt["scheduler_state_dict"] = scheduler.state_dict()
+
+    # save scene(s)
+    ckpt["scene_default"] = default_scene.radiance_field.state_dict()
+    if not fine_scene is None:
+        ckpt["scene_fine"] = fine_scene.radiance_field.state_dict()
 
     torch.save(
         ckpt,

--- a/torch_nerf/runners/runner_utils.py
+++ b/torch_nerf/runners/runner_utils.py
@@ -142,6 +142,21 @@ def _init_renderer(cfg: DictConfig):
     return renderer
 
 
+def _init_tensorboard(tb_log_dir: str) -> SummaryWriter:
+    """
+    Initializes tensorboard writer.
+
+    Args:
+        tb_log_dir (str): A directory where Tensorboard logs will be saved.
+
+    Returns:
+        writer (SummaryWriter): A writer (handle) for logging data.
+    """
+    if not os.path.exists(tb_log_dir):
+        os.mkdir(tb_log_dir)
+    writer = SummaryWriter(log_dir=tb_log_dir)
+    return writer
+
 
 def _init_scene_repr(cfg: DictConfig) -> Tuple[scene.PrimitiveBase, Optional[scene.PrimitiveBase]]:
     """

--- a/torch_nerf/runners/runner_utils.py
+++ b/torch_nerf/runners/runner_utils.py
@@ -180,7 +180,8 @@ def _build_train_routine(
             Set to None by default.
 
     Returns:
-        train_one_epoch (Callable):
+        train_one_epoch (functools.partial): A function that trains a neural scene representation
+            for one epoch.
     """
     # resolve training configuration
     use_hierarchical_sampling = not fine_scene is None
@@ -385,7 +386,7 @@ def _build_visualization_routine(
         renderer (VolumeRenderer): Volume renderer used to render the scene.
 
     Returns:
-        visualize_scene (Callable):
+        visualize_scene (functools.partial): A function that visualizes a neural scene representation.
     """
     visualize_scene = functools.partial(
         _visualize_scene,

--- a/torch_nerf/src/scene/__init__.py
+++ b/torch_nerf/src/scene/__init__.py
@@ -1,2 +1,2 @@
-from torch_nerf.src.scene.primitives.primitive_base import *
-from torch_nerf.src.scene.primitives.cube import PrimitiveCube
+from torch_nerf.src.scene.primitives import *
+from torch_nerf.src.scene.scene import Scene

--- a/torch_nerf/src/scene/primitives/__init__.py
+++ b/torch_nerf/src/scene/primitives/__init__.py
@@ -1,0 +1,3 @@
+from torch_nerf.src.scene.primitives.primitive_base import PrimitiveBase
+from torch_nerf.src.scene.primitives.cube import PrimitiveCube
+from torch_nerf.src.scene.primitives.hash_table import MultiResHashTable

--- a/torch_nerf/src/scene/primitives/primitive_base.py
+++ b/torch_nerf/src/scene/primitives/primitive_base.py
@@ -3,6 +3,7 @@ Base class for scene primitives.
 """
 
 from typing import Dict, Optional, Tuple
+import warnings
 
 import torch
 from torch_nerf.src.signal_encoder.signal_encoder_base import SignalEncoderBase
@@ -21,11 +22,9 @@ class PrimitiveBase(object):
             if not isinstance(encoders, dict):
                 raise ValueError(f"Expected a parameter of type Dict. Got {type(encoders)}")
             if not "coord_enc" in encoders.keys():
-                raise ValueError(
-                    f"Missing required encoder type 'coord_enc'. Got {encoders.keys()}."
-                )
+                warnings.warn(f"Missing an encoder type 'coord_enc'. Got {encoders.keys()}.")
             if not "dir_enc" in encoders.keys():
-                raise ValueError(f"Missing required encoder type 'dir_enc'. Got {encoders.keys()}.")
+                warnings.warn(f"Missing an encoder type 'dir_enc'. Got {encoders.keys()}.")
         self._encoders = encoders
 
     def query_points(

--- a/torch_nerf/src/scene/scene.py
+++ b/torch_nerf/src/scene/scene.py
@@ -1,0 +1,45 @@
+from typing import Sequence, Tuple
+
+import torch
+from torch_nerf.src.scene.primitives import PrimitiveBase
+
+
+class Scene:
+    """
+    Scene object representing an renderable scene.
+
+    Attributes:
+
+    """
+
+    def __init__(self, primitives: Sequence[PrimitiveBase]):
+        """
+        Constructor for 'Scene'.
+
+        Args:
+            primitives (Sequence[PrimitiveBase]): A collection of scene primitives.
+        """
+        self._primitives = primitives
+
+    def query_points(
+        self,
+        pos: torch.Tensor,
+        view_dir: torch.Tensor,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        """
+        Query 3D scene to retrieve radiance and density values.
+
+        TODO: Extend the implementation to support
+        primitive hierarchy, KD-tree like spatial structure, etc.
+
+        Args:
+            pos (torch.Tensor): 3D coordinates of sample points.
+            view_dir (torch.Tensor): View direction vectors associated with sample points.
+
+        Returns:
+            sigma (torch.Tensor): An instance of torch.Tensor of shape (N, S).
+                The density at each sample point.
+            radiance (torch.Tensor): An instance of torch.Tensor of shape (N, S, 3).
+                The radiance at each sample point.
+        """
+        return self._primitives.query_points(pos, view_dir)


### PR DESCRIPTION
This PR introduces:
- runners (`runners/run_train.py`, `runners/run_render.py`) agnostic to model structure, training strategy, etc
- `runners/runner_utils.py` packed with easy-to-understand initialization codes
- `session` as the execution unit of training and rendering (powered by a little bit of _functional programming_)